### PR TITLE
Fix duplicate closing tags in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,6 +302,3 @@
 
 </body>
 </html>
-
-</body>
-</html>


### PR DESCRIPTION
## Summary
- remove extra `</body>` and `</html>` tags from `index.html`

## Testing
- `tidy -q -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f90053bc08329b09bf5f201a707b3